### PR TITLE
Remove reference to spaceman

### DIFF
--- a/docs/blog/2023-10-05-zmk-sotf-6.md
+++ b/docs/blog/2023-10-05-zmk-sotf-6.md
@@ -215,7 +215,7 @@ USB HID polling interval now defaults to 1 ms, i.e. a 1000Hz polling rate, thank
 - Waterfowl [#1554](https://github.com/zmkfirmware/zmk/pull/1554) - [JW2586](https://github.com/JW2586)
 - Kyria Rev 3 [#1627](https://github.com/zmkfirmware/zmk/pull/1627) - [petejohanson]
 - Leeloo v2 and Leeloo-Micro [#1762](https://github.com/zmkfirmware/zmk/pull/1762) - [ClicketySplit](https://github.com/ClicketySplit)
-- Spaceman Pancake [#1400](https://github.com/zmkfirmware/zmk/pull/1400) - [jasonhazel](https://github.com/jasonhazel)
+- Spaceboards Pancake [#1400](https://github.com/zmkfirmware/zmk/pull/1400) - [jasonhazel](https://github.com/jasonhazel)
 - Reviung5 [#1548](https://github.com/zmkfirmware/zmk/pull/1548) - [zblesk](https://github.com/zblesk)
 
 ## New Boards


### PR DESCRIPTION
Removed dated reference to spaceman a username no longer assigned to me and replaced with the spaceboards organization https://github.com/spaceboards